### PR TITLE
Add secure parameter to force https

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -13,6 +13,7 @@ class Client extends EventEmitter {
 
         const agent = this.agent = options.agent;
         const id = this.id = options.id;
+        const secure = this.secure = options.secure;
 
         this.debug = Debug(`lt:Client[${this.id}]`);
 
@@ -56,6 +57,14 @@ class Client extends EventEmitter {
     }
 
     handleRequest(req, res) {
+        if(!req.secure && this.secure) {
+            // Must redirect to https
+            this.debug('Redirect to https > %s', req.url);
+            let urlObject = url.parse('http://' + this.request.header.host);
+            let httpsHost = urlObject.hostname;
+            res.redirect('https://' + httpsHost + this.request.url);
+        }
+
         this.debug('> %s', req.url);
         const opt = {
             path: req.url,

--- a/lib/ClientManager.js
+++ b/lib/ClientManager.js
@@ -28,7 +28,7 @@ class ClientManager {
     // create a new tunnel with `id`
     // if the id is already used, a random id is assigned
     // if the tunnel could not be created, throws an error
-    async newClient(id) {
+    async newClient(id, secure) {
         const clients = this.clients;
         const stats = this.stats;
 
@@ -46,6 +46,7 @@ class ClientManager {
         const client = new Client({
             id,
             agent,
+            secure,
         });
 
         // add to clients map immediately

--- a/server.js
+++ b/server.js
@@ -64,10 +64,12 @@ export default function(opt) {
         }
 
         const isNewClientRequest = ctx.query['new'] !== undefined;
+        const isSecure = ctx.query['secure'] !== undefined;
+
         if (isNewClientRequest) {
             const reqId = hri.random();
             debug('making new client with id %s', reqId);
-            const info = await manager.newClient(reqId);
+            const info = await manager.newClient(reqId, isSecure);
 
             const url = schema + '://' + info.id + '.' + ctx.request.host;
             info.url = url;
@@ -105,7 +107,8 @@ export default function(opt) {
         }
 
         debug('making new client with id %s', reqId);
-        const info = await manager.newClient(reqId);
+        const isSecure = ctx.query['secure'] !== undefined;
+        const info = await manager.newClient(reqId, isSecure);
 
         const url = schema + '://' + info.id + '.' + ctx.request.host;
         info.url = url;


### PR DESCRIPTION
This pull request will allow to client to send a query parameter called secure to force the redirection over https if the request is coming from an insecure http url.

(Maybe todo : create an option in the server to be able to deactivate this feature.)