### PR TITLE
add a docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ ENV NODE_ENV production
 ENTRYPOINT ["node", "-r", "esm", "./bin/server"]
 
 HEALTHCHECK --start-period=30s \
-  CMD curl -s localhost:$(netstat -nltWep | grep 1/node | awk '{ print $4 }'| cut -d ":" -f 2) || exit 1  
+  CMD curl -s localhost:$(netstat -nltWep | grep 1/node | awk '{ print $4 }'| cut -d ":" -f 2)/api/status || exit 1  

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:10.1.0-alpine
+RUN apk add --no-cache curl
 
 WORKDIR /app
 
@@ -11,3 +12,6 @@ COPY . /app
 
 ENV NODE_ENV production
 ENTRYPOINT ["node", "-r", "esm", "./bin/server"]
+
+HEALTHCHECK --start-period=30s \
+  CMD curl -s localhost:$(netstat -nltWep | grep 1/node | awk '{ print $4 }'| cut -d ":" -f 2) || exit 1  


### PR DESCRIPTION
in relation to https://github.com/localtunnel/localtunnel/issues/215#issuecomment-423824738

Ideally the port would be an env var rather than a process argument which would make the healthcheck a lot less ugly.

What I first have to do is figure out what port its listening on, and then curl it.

I'll assume if it responds to a curl on that port the server is healthy