### PR TITLE
Support non-standard ports

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,7 +18,8 @@ export default function(opt) {
     const landingPage = opt.landing || 'https://localtunnel.github.io/www/';
 
     function GetClientIdFromHostname(hostname) {
-        return myTldjs.getSubdomain(hostname);
+        const pieces = hostname.split(':');
+        return myTldjs.getSubdomain(pieces[0]);
     }
 
     const manager = new ClientManager(opt);


### PR DESCRIPTION
Support non-standard ports - ran into this when building https://github.com/jmather/localtunnel-secure-server.