### PR TITLE
Redirect www subdomain to landingPage if the tunnel does not exist

### DIFF
--- a/server.js
+++ b/server.js
@@ -134,6 +134,11 @@ export default function(opt) {
 
         const client = manager.getClient(clientId);
         if (!client) {
+            if (clientId === 'www') {
+                res.writeHead(301, {'Location' : landingPage});
+                res.end();
+                return;
+            }
             res.statusCode = 404;
             res.end('404');
             return;


### PR DESCRIPTION
The www is used often to refer to the main domain, so redirect to it if no alternative tunnel exists.