### PR TITLE
Adding button to deploy to Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 localtunnel exposes your localhost to the world for easy testing and sharing! No need to mess with DNS or deploy just to have others test out your changes.
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/localtunnel/server)
+
 This repo is the server component. If you are just looking for the CLI localtunnel app, see (https://github.com/localtunnel/localtunnel).
 
 ## overview ##

--- a/app.json
+++ b/app.json
@@ -1,0 +1,5 @@
+{
+    "name": "localtunnel-server",
+    "description": "localtunnel exposes your localhost to the world for easy testing and sharing!",
+    "repository": "https://github.com/localtunnel/server"
+}

--- a/bin/server
+++ b/bin/server
@@ -17,7 +17,7 @@ const argv = optimist
         describe: 'use this flag to indicate proxy over https'
     })
     .options('port', {
-        default: '80',
+        default: process.env.PORT || '80',
         describe: 'listen on this port for outside requests'
     })
     .options('address', {


### PR DESCRIPTION
To solve the problem of ports I made a condition to use the ENV `PORT` value returned by most clounds otherwise use the default port 80.

I currently use this implementation without any problems.

Note: The button will only work when the PR is merged, because the `app.json` file must be present in the repository.

closes #88 and closes #114