### PR TITLE
Fix typos in subdomain example

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -25,7 +25,7 @@ const argv = optimist
         describe: 'IP address to bind to'
     })
     .options('domain', {
-        describe: 'Specify the base domain name. This is optional if hosting localtunnel from a regular example.com domain. This is required if hosting a localtunnel server from a subdomain (i.e. lt.example.dom where clients will be client-app.lt.example.come)',
+        describe: 'Specify the base domain name. This is optional if hosting localtunnel from a regular example.com domain. This is required if hosting a localtunnel server from a subdomain (i.e. lt.example.com where clients will be client-app.lt.example.com)',
     })
     .options('max-sockets', {
         default: 10,


### PR DESCRIPTION
- Sentence leads with `example.com`
- `dom` and `come` → `com` for consistency